### PR TITLE
Add initial implementation of SDM630 Modbus to MQTT bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# ha-addon-sdm630-mqtt
-Repository for Eastron DSM630 inegration with Home Assistant
+# SDM630 Modbus → MQTT Bridge (Home Assistant Add-on)
+
+Deze add-on leest een **Eastron SDM630 kWh-meter** via een **USR-TCP232-410S (RS485 ↔ Ethernet)** 
+en publiceert de data naar een MQTT broker (bij voorkeur de Home Assistant core-mosquitto add-on).
+
+## Installatie
+1. Voeg deze repository toe in Home Assistant → Add-on store → Repositories.
+2. Installeer **SDM630 MQTT Bridge**.
+3. Configureer het IP-adres en de instellingen van de USR-TCP232-410S.
+4. Start de add-on → meetdata verschijnt in MQTT.
+
+## MQTT topic voorbeeld
+```json
+{
+  "voltage_l1": 229.4,
+  "voltage_l2": 228.9,
+  "voltage_l3": 230.1,
+  "current_l1": 1.23,
+  "current_l2": 0.87,
+  "current_l3": 1.05,
+  "power_total": 1500.2,
+  "energy_import": 12345.6,
+  "energy_export": 234.5
+}

--- a/sdm630-mqtt/Dockerfile
+++ b/sdm630-mqtt/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN pip install pymodbus==3.6.9 paho-mqtt==2.1.0
+
+COPY sdm630.py run.sh /app/
+
+RUN chmod +x /app/run.sh
+
+CMD ["/app/run.sh"]

--- a/sdm630-mqtt/config.json
+++ b/sdm630-mqtt/config.json
@@ -1,0 +1,25 @@
+{
+  "name": "SDM630 Modbus → MQTT Bridge",
+  "version": "1.0.0",
+  "slug": "sdm630_mqtt",
+  "description": "Bridge voor Eastron SDM630 via USR-TCP232-410S naar MQTT",
+  "arch": ["amd64", "armv7", "armhf", "aarch64"],
+  "startup": "services",
+  "boot": "auto",
+  "options": {
+    "usr_ip": "192.168.1.182",
+    "usr_port": 502,
+    "slave_id": 1,
+    "mqtt_broker": "core-mosquitto",
+    "mqtt_port": 1883,
+    "mqtt_topic": "home/sdm630"
+  },
+  "schema": {
+    "usr_ip": "str",
+    "usr_port": "int",
+    "slave_id": "int",
+    "mqtt_broker": "str",
+    "mqtt_port": "int",
+    "mqtt_topic": "str"
+  }
+}

--- a/sdm630-mqtt/run.sh
+++ b/sdm630-mqtt/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "Starting SDM630 MQTT bridge..."
+python /app/sdm630.py

--- a/sdm630-mqtt/sdm630.py
+++ b/sdm630-mqtt/sdm630.py
@@ -1,0 +1,53 @@
+import os
+import time
+import struct
+import json
+from pymodbus.client import ModbusTcpClient
+import paho.mqtt.publish as publish
+
+def read_float(client, reg, slave_id):
+    rr = client.read_input_registers(reg, 2, unit=slave_id)
+    if rr.isError():
+        return None
+    val = (rr.registers[0] << 16) + rr.registers[1]
+    return struct.unpack('>f', val.to_bytes(4, 'big'))[0]
+
+def main():
+    usr_ip = os.getenv("USR_IP", "192.168.1.100")
+    usr_port = int(os.getenv("USR_PORT", "502"))
+    slave_id = int(os.getenv("SLAVE_ID", "1"))
+    mqtt_broker = os.getenv("MQTT_BROKER", "core-mosquitto")
+    mqtt_port = int(os.getenv("MQTT_PORT", "1883"))
+    mqtt_topic = os.getenv("MQTT_TOPIC", "home/sdm630")
+
+    client = ModbusTcpClient(usr_ip, port=usr_port)
+
+    while True:
+        try:
+            if not client.connect():
+                print("❌ Kan geen verbinding maken met Modbus TCP")
+                time.sleep(5)
+                continue
+
+            data = {
+                "voltage_l1": read_float(client, 0, slave_id),
+                "voltage_l2": read_float(client, 2, slave_id),
+                "voltage_l3": read_float(client, 4, slave_id),
+                "current_l1": read_float(client, 6, slave_id),
+                "current_l2": read_float(client, 8, slave_id),
+                "current_l3": read_float(client, 10, slave_id),
+                "power_total": read_float(client, 52, slave_id),
+                "energy_import": read_float(client, 72, slave_id),
+                "energy_export": read_float(client, 74, slave_id)
+            }
+
+            publish.single(mqtt_topic, json.dumps(data), hostname=mqtt_broker, port=mqtt_port)
+            print("✅ Data gepubliceerd:", data)
+
+        except Exception as e:
+            print("⚠️ Fout:", e)
+
+        time.sleep(10)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Created README.md with installation instructions and example MQTT topic.
- Added Dockerfile for container setup with required dependencies.
- Implemented main functionality in sdm630.py to read data from SDM630 and publish to MQTT.
- Included run.sh script to start the application.
- Defined configuration schema in config.json for user settings.